### PR TITLE
Fix unsigned beatmapId

### DIFF
--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -96,7 +96,7 @@ func (status Status) String() string {
 
 type BeatmapInfo struct {
 	Checksum string
-	Id       uint32
+	Id       int32
 	Artist   string
 	Title    string
 	Version  string

--- a/hnet/parsers.go
+++ b/hnet/parsers.go
@@ -58,7 +58,7 @@ func ReadStatusChange(stream *common.IOStream) *Status {
 
 	status.Beatmap = &BeatmapInfo{
 		Checksum: stream.ReadString(),
-		Id:       stream.ReadU32(),
+		Id:       stream.ReadI32(),
 		Artist:   stream.ReadString(),
 		Title:    stream.ReadString(),
 		Version:  stream.ReadString(),

--- a/hnet/writers.go
+++ b/hnet/writers.go
@@ -43,7 +43,7 @@ func (status Status) Serialize(stream *common.IOStream) {
 
 func (info BeatmapInfo) Serialize(stream *common.IOStream) {
 	stream.WriteString(info.Checksum)
-	stream.WriteU32(info.Id)
+	stream.WriteI32(info.Id)
 	stream.WriteString(info.Artist)
 	stream.WriteString(info.Title)
 	stream.WriteString(info.Version)


### PR DESCRIPTION
Unsubmitted beatmaps have an id of -1, which is 4 billion in uint32.