### PR TITLE
Rename Unknown to Password

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright (c) 2023 Levi <contact@lekuru.xyz>
+Copyright (c) 2024 Levi <contact@lekuru.xyz>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -37,7 +37,7 @@ func handleLogin(stream *common.IOStream, player *Player) error {
 	response := LoginResponse{
 		UserId:   player.Id,
 		Username: player.Name,
-		Unknown:  "Test",
+		Password: request.Password,
 	}
 
 	return player.SendPacket(SERVER_LOGIN_RESPONSE, response)

--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -115,15 +115,15 @@ func (beatmap BeatmapInfo) String() string {
 
 type LoginResponse struct {
 	Username string
-	Unknown  string // TODO
+	Password string
 	UserId   uint32
 }
 
 func (response LoginResponse) String() string {
 	return fmt.Sprintf(
-		"LoginResponse{Username: %s, Unknown: %s, UserId: %d}",
+		"LoginResponse{Username: %s, Password: %s, UserId: %d}",
 		response.Username,
-		response.Unknown,
+		response.Password,
 		response.UserId,
 	)
 }

--- a/hnet/writers.go
+++ b/hnet/writers.go
@@ -51,6 +51,6 @@ func (info BeatmapInfo) Serialize(stream *common.IOStream) {
 
 func (response LoginResponse) Serialize(stream *common.IOStream) {
 	stream.WriteString(response.Username)
-	stream.WriteString(response.Unknown)
+	stream.WriteString(response.Password)
 	stream.WriteU32(response.UserId)
 }


### PR DESCRIPTION
The `Unknown` field in the login response is actually the password, which for some reason is not checked client side. This password will be sent in all future requests though, so maybe it's worth hashing?