### PR TITLE
Implement status sending, and add base of friends list packet

### DIFF
--- a/hnet/collections.go
+++ b/hnet/collections.go
@@ -45,6 +45,13 @@ func (collection *PlayerCollection) All() []Player {
 	return players
 }
 
+func (collection *PlayerCollection) Broadcast(packetId uint32, packet Serializable) {
+	for _, player := range collection.All() {
+		player.LogOutgoingPacket(packetId, packet)
+		player.SendPacket(packetId, packet)
+	}
+}
+
 func NewPlayerCollection() PlayerCollection {
 	return PlayerCollection{
 		idMap:   make(map[uint32]*Player),

--- a/hnet/constants.go
+++ b/hnet/constants.go
@@ -10,11 +10,16 @@ const (
 	SERVER_LOGIN_RESPONSE uint32 = 2
 	SERVER_USER_STATS     uint32 = 5
 	SERVER_USER_INFO      uint32 = 6
+	SERVER_FRIENDS_LIST   uint32 = 8
 )
 
 const (
-	ACTION_IDLE    uint32 = 1
-	ACTION_PLAYING uint32 = 3
-	ACTION_EDITING uint32 = 5
-	ACTION_TESTING uint32 = 6
+	ACTION_IDLE       uint32 = 1
+	ACTION_AWAY       uint32 = 2
+	ACTION_PLAYING    uint32 = 3
+	ACTION_EDITING    uint32 = 4
+	ACTION_MODDING    uint32 = 5
+	ACTION_TESTING    uint32 = 6
+	ACTION_SUBMITTING uint32 = 7
+	ACTION_WATCHING   uint32 = 8
 )

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -63,15 +63,7 @@ func handleStatusChange(stream *common.IOStream, player *Player) error {
 		return fmt.Errorf("failed to read status change")
 	}
 
-	player.Status = status
-
-	statsResponse := StatsResponse{
-		Stats:  player.Stats,
-		Status: player.Status,
-	}
-
-	player.Server.Players.Broadcast(SERVER_USER_STATS, statsResponse)
-
+	player.Stats.Status = status
 	player.LogIncomingPacket(CLIENT_CHANGE_STATUS, status)
 	return nil
 }
@@ -92,12 +84,7 @@ func handleRequestStats(stream *common.IOStream, player *Player) error {
 			continue
 		}
 
-		statsResponse := StatsResponse{
-			Stats:  user.Stats,
-			Status: user.Status,
-		}
-
-		player.SendPacket(SERVER_USER_STATS, statsResponse)
+		player.SendPacket(SERVER_USER_STATS, user.Stats)
 	}
 
 	return nil

--- a/hnet/handler.go
+++ b/hnet/handler.go
@@ -64,6 +64,14 @@ func handleStatusChange(stream *common.IOStream, player *Player) error {
 	}
 
 	player.Status = status
+
+	statsResponse := StatsResponse{
+		Stats:  player.Stats,
+		Status: player.Status,
+	}
+
+	player.Server.Players.Broadcast(SERVER_USER_STATS, statsResponse)
+
 	player.LogIncomingPacket(CLIENT_CHANGE_STATUS, status)
 	return nil
 }
@@ -84,7 +92,12 @@ func handleRequestStats(stream *common.IOStream, player *Player) error {
 			continue
 		}
 
-		player.SendPacket(SERVER_USER_STATS, user.Stats)
+		statsResponse := StatsResponse{
+			Stats:  user.Stats,
+			Status: user.Status,
+		}
+
+		player.SendPacket(SERVER_USER_STATS, statsResponse)
 	}
 
 	return nil

--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -163,11 +163,12 @@ type UserStats struct {
 	Unknown2 uint32
 	Accuracy float64
 	Plays    uint32
+	Status   *Status
 }
 
 func (stats UserStats) String() string {
 	return fmt.Sprintf(
-		"UserStats{UserId: %d, Rank: %d, Score: %d, Unknown: %d, Unknown2: %d, Accuracy: %f, Plays: %d}",
+		"UserStats{UserId: %d, Rank: %d, Score: %d, Unknown: %d, Unknown2: %d, Accuracy: %f, Plays: %d, %s}",
 		stats.UserId,
 		stats.Rank,
 		stats.Score,
@@ -175,6 +176,7 @@ func (stats UserStats) String() string {
 		stats.Unknown2,
 		stats.Accuracy*100,
 		stats.Plays,
+		stats.Status.String(),
 	)
 }
 
@@ -186,6 +188,7 @@ func NewUserStats() *UserStats {
 		Unknown2: 0,
 		Accuracy: 0.0,
 		Plays:    0,
+		Status:   NewStatus(),
 	}
 }
 
@@ -203,26 +206,6 @@ func (request StatsRequest) String() string {
 func NewStatsRequest() *StatsRequest {
 	return &StatsRequest{
 		UserIds: make([]uint32, 0),
-	}
-}
-
-type StatsResponse struct {
-	Stats  *UserStats
-	Status *Status
-}
-
-func (response StatsResponse) String() string {
-	return fmt.Sprintf(
-		"StatsResponse{Stats: %v, Status: %v}",
-		response.Stats,
-		response.Status,
-	)
-}
-
-func NewStatsResponse() *StatsResponse {
-	return &StatsResponse{
-		Stats:  NewUserStats(),
-		Status: NewStatus(),
 	}
 }
 

--- a/hnet/objects.go
+++ b/hnet/objects.go
@@ -75,9 +75,7 @@ type Status struct {
 }
 
 func (status Status) HasBeatmapInfo() bool {
-	return status.Action == ACTION_PLAYING ||
-		status.Action == ACTION_EDITING ||
-		status.Action == ACTION_TESTING
+	return status.Action > ACTION_AWAY
 }
 
 func (status Status) String() string {
@@ -92,6 +90,14 @@ func (status Status) String() string {
 		strconv.Itoa(int(status.Action)),
 		beatmapString,
 	)
+}
+
+func NewStatus() *Status {
+	return &Status{
+		UserId:  0,
+		Action:  1,
+		Beatmap: nil,
+	}
 }
 
 type BeatmapInfo struct {
@@ -197,5 +203,42 @@ func (request StatsRequest) String() string {
 func NewStatsRequest() *StatsRequest {
 	return &StatsRequest{
 		UserIds: make([]uint32, 0),
+	}
+}
+
+type StatsResponse struct {
+	Stats  *UserStats
+	Status *Status
+}
+
+func (response StatsResponse) String() string {
+	return fmt.Sprintf(
+		"StatsResponse{Stats: %v, Status: %v}",
+		response.Stats,
+		response.Status,
+	)
+}
+
+func NewStatsResponse() *StatsResponse {
+	return &StatsResponse{
+		Stats:  NewUserStats(),
+		Status: NewStatus(),
+	}
+}
+
+type FriendsList struct {
+	FriendIds []uint32
+}
+
+func (friends FriendsList) String() string {
+	return fmt.Sprintf(
+		"FriendsList{Friends: %v}",
+		friends.FriendIds,
+	)
+}
+
+func NewFriendsList() *FriendsList {
+	return &FriendsList{
+		FriendIds: []uint32{},
 	}
 }

--- a/hnet/player.go
+++ b/hnet/player.go
@@ -16,7 +16,6 @@ type Player struct {
 	Client  *ClientInfo
 	Info    *UserInfo
 	Stats   *UserStats
-	Status  *Status
 }
 
 func (player *Player) Send(data []byte) error {

--- a/hnet/writers.go
+++ b/hnet/writers.go
@@ -58,7 +58,7 @@ func (response LoginResponse) Serialize(stream *common.IOStream) {
 func (presence UserInfo) Serialize(stream *common.IOStream) {
 	stream.WriteU32(presence.Id)
 	stream.WriteString(presence.Name)
-	stream.WriteU32(69)
+	stream.WriteU16(1)
 	stream.WriteString("Test")
 	stream.WriteString("Test1")
 	stream.WriteString("Test2")
@@ -76,4 +76,13 @@ func (stats UserStats) Serialize(stream *common.IOStream) {
 
 func (request StatsRequest) Serialize(stream *common.IOStream) {
 	stream.WriteIntList(request.UserIds)
+}
+
+func (response StatsResponse) Serialize(stream *common.IOStream) {
+	response.Stats.Serialize(stream)
+	response.Status.Serialize(stream)
+}
+
+func (friends FriendsList) Serialize(stream *common.IOStream) {
+	stream.WriteIntList(friends.FriendIds)
 }

--- a/hnet/writers.go
+++ b/hnet/writers.go
@@ -72,15 +72,11 @@ func (stats UserStats) Serialize(stream *common.IOStream) {
 	stream.WriteU32(stats.Unknown2)
 	stream.WriteF64(stats.Accuracy)
 	stream.WriteU32(stats.Plays)
+	stats.Status.Serialize(stream)
 }
 
 func (request StatsRequest) Serialize(stream *common.IOStream) {
 	stream.WriteIntList(request.UserIds)
-}
-
-func (response StatsResponse) Serialize(stream *common.IOStream) {
-	response.Stats.Serialize(stream)
-	response.Status.Serialize(stream)
 }
 
 func (friends FriendsList) Serialize(stream *common.IOStream) {


### PR DESCRIPTION
LOTS of changes here
- finish list of known statuses
- implement a `StatsResponse` struct that can serialise both stats and status
- implement a `FriendsList` struct (we will use this when db is added)
- allow for global packet broadcasting
- broadcast stats packet on status update